### PR TITLE
Vinyl Goal Update & IPFS Host Change

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -30,6 +30,9 @@ const nextConfig = {
 				hostname: "zora-prod.mypinata.cloud",
 			},
 			{
+				hostname: "magic.decentralized-content.com",
+			},
+			{
 				hostname: "gnvpkbsguukbuvppslse.supabase.co",
 			},
 		],

--- a/packages/utils/config.ts
+++ b/packages/utils/config.ts
@@ -1,6 +1,6 @@
 export const COLLECTION_ADDRESS = "0xdb0e162a0d8ac56fe673411c27dc50b73954ee8d";
 export const DOWNLOADS_GOAL = 20;
-export const VINYL_GOAL = 1111;
+export const VINYL_GOAL = 111;
 export const ZORA_API_ENDPOINT = "https://api.zora.co/graphql";
 export const MAX_MINT_AMOUNT = 111;
 export const TOKEN_PRICE_ETH = 0.000777;

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -16,8 +16,10 @@ export function formatAddress(address?: string): string {
 
 export function ipfsToUrl(ipfsAddress?: string | null): string {
 	return (
-		ipfsAddress?.replace("ipfs://", "https://zora-prod.mypinata.cloud/ipfs/") ??
-		""
+		ipfsAddress?.replace(
+			"ipfs://",
+			"https://magic.decentralized-content.com/ipfs/",
+		) ?? ""
 	);
 }
 


### PR DESCRIPTION
## Description
Updated the IPFS host to Zora.co's current one because the Pinata host was giving 504 errors. Also changed vinyl goal from 1111 to 111.

## Type of Change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules